### PR TITLE
Updated to xUnit 2.0.  Leveraged the IClassFixture interface on many …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono:
-  - 4.2
+  - alpha
 env: VERSION=0.3.8
 solution: Elephanet.sln
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono:
-  - latest
+  - 4.2
 env: VERSION=0.3.8
 solution: Elephanet.sln
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 
 script:
   - xbuild /p:Configuration=Release Elephanet.sln
-  - mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe  ./Elephanet.Tests/bin/Release/Elephanet.Tests.dll
+  - mono ./packages/xunit.runner.console.2.0.0/tools/xunit.console.exe  ./Elephanet.Tests/bin/Release/Elephanet.Tests.dll
   - chmod 755 ./packages/ILRepack.1.25.0/tools/ILRepack.exe
   - ./packages/ILRepack.1.25.0/tools/ILRepack.exe Elephanet/bin/Release/Elephanet.dll Elephanet/bin/Release/Sigil.dll Elephanet/bin/Release/Jil.dll Elephanet/bin/Release/Mono.Security.dll Elephanet/bin/Release/Npgsql.dll --internalize --out:Elephanet/Elephanet.dll
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - latest
 env: VERSION=0.3.8
 solution: Elephanet.sln
 addons:

--- a/Elephanet.Tests/DocumentStoreBaseFixture.cs
+++ b/Elephanet.Tests/DocumentStoreBaseFixture.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Elephanet.Tests
+{
+    /// <summary>
+    /// Use this as an IClassFixture to inject the TestStore into other test fixtures
+    /// </summary>
+    public class DocumentStoreBaseFixture : IDisposable
+    {
+        public DocumentStoreBaseFixture()
+        {
+            TestStore = new TestStore();
+        }
+
+        public TestStore TestStore { get; private set; }
+
+        public void Dispose()
+        {
+            TestStore.Destroy();
+        }
+    }
+}

--- a/Elephanet.Tests/Elephanet.Tests.csproj
+++ b/Elephanet.Tests/Elephanet.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -12,7 +13,8 @@
     <AssemblyName>Elephanet.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>8b3cd587</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -48,14 +50,24 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bike.cs" />
     <Compile Include="Car.cs" />
     <Compile Include="DirtySpeedTests.cs" />
+    <Compile Include="DocumentStoreBaseFixture.cs" />
     <Compile Include="GetAllTests.cs" />
     <Compile Include="GetByIdTests.cs" />
     <Compile Include="JsonConverterTests.cs" />
@@ -88,6 +100,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Elephanet.Tests/GetAllTests.cs
+++ b/Elephanet.Tests/GetAllTests.cs
@@ -6,18 +6,28 @@ using Xunit;
 
 namespace Elephanet.Tests
 {
-    public class GetAllTests
+    public class GetAllTests : IClassFixture<DocumentStoreBaseFixture>, IDisposable
     {
+        private TestStore _store;
+
+        public GetAllTests(DocumentStoreBaseFixture data)
+        {
+            _store = data.TestStore;
+        }
 
         [Fact]
         public void GetAllCreatesTheTableIfItDoesNotExist()
         {
-            var store = new TestStore();
-            using (var session = store.OpenSession())
+            using (var session = _store.OpenSession())
             {
                 var things = session.GetAll<SomeTestClassThatNoOneWillEverUse>().ToList();
                 things.Count.ShouldBe(0);
             }
+        }
+
+        public void Dispose()
+        {
+            
         }
     }
 

--- a/Elephanet.Tests/GetByIdTests.cs
+++ b/Elephanet.Tests/GetByIdTests.cs
@@ -7,17 +7,15 @@ using System;
 
 namespace Elephanet.Tests
 {
-    public class GetByIdTests : IDisposable
+    public class GetByIdTests : IClassFixture<DocumentStoreBaseFixture>, IDisposable
     {
-        private readonly StoreInfo _testStore;
-        private readonly DocumentStore _store;
-        private readonly List<Car> dummyCars;
+        private readonly TestStore _store;
+        private readonly List<CarGetById> dummyCars;
 
-        public  GetByIdTests()
+        public GetByIdTests(DocumentStoreBaseFixture data)
         {
-            _testStore = new StoreInfo();
-            _store = new TestStore(); 
-            dummyCars =  new Fixture().CreateMany<Car>().ToList();
+            _store = data.TestStore; 
+            dummyCars = new Fixture().CreateMany<CarGetById>().ToList();
             using (var session = _store.OpenSession())
             {
                 foreach (var car in dummyCars)
@@ -34,7 +32,7 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var first = session.GetById<Car>(dummyCars[0].Id);
+                var first = session.GetById<CarGetById>(dummyCars[0].Id);
                 first.ShouldNotBe(null);
             }
         }
@@ -44,11 +42,10 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var cars = session.GetByIds<Car>(dummyCars.Select(c => c.Id).ToList()).ToList();
+                var cars = session.GetByIds<CarGetById>(dummyCars.Select(c => c.Id).ToList()).ToList();
                 cars[0].Id.ShouldBe(dummyCars[0].Id);
                 cars[2].Id.ShouldBe(dummyCars[2].Id);
             }
-
         }
 
         [Fact]
@@ -58,7 +55,7 @@ namespace Elephanet.Tests
             {   
                 Should.Throw<EntityNotFoundException>(() =>
                 {
-                    session.GetById<Car>(Guid.NewGuid());
+                    session.GetById<CarGetById>(Guid.NewGuid());
                 });
             }
         }
@@ -69,7 +66,7 @@ namespace Elephanet.Tests
             var store = TestStore.CreateStoreWithEntityNotFoundBehaviorReturnNull();
             using (var session = store.OpenSession())
             {
-                session.GetById<Car>(Guid.NewGuid())
+                session.GetById<CarGetById>(Guid.NewGuid())
                     .ShouldBe(null);
             }
         }
@@ -79,14 +76,29 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var cars = session.GetAll<Car>().ToList();
+                var cars = session.GetAll<CarGetById>().ToList();
                 cars.Count.ShouldBe(3);
             }
         }
 
         public void Dispose()
         {
-            _store.Destroy();
+            using (var session = _store.OpenSession())
+            {
+                session.DeleteAll<CarGetById>();
+            }
         }
+
+       
+    }
+
+    public class CarGetById
+    {
+        public Guid Id { get; set; }
+        public string Make { get; set; }
+        public string Model { get; set; }
+        public string ImageUrl { get; set; }
+        public string NumberPlate { get; set; }
+        public DateTime CreatedAt { get; set; }
     }
 }

--- a/Elephanet.Tests/LinqOrderByTests.cs
+++ b/Elephanet.Tests/LinqOrderByTests.cs
@@ -6,31 +6,28 @@ using System;
 
 namespace Elephanet.Tests
 {
-    public class LinqOrderByTests : IDisposable
+    public class LinqOrderByTests : IClassFixture<DocumentStoreBaseFixture>, IDisposable
     {
-        private StoreInfo _testStore;
         private TestStore _store;
 
-        public LinqOrderByTests()
+        public LinqOrderByTests(DocumentStoreBaseFixture data)
         {
-            _testStore = new StoreInfo();
-            _store = new TestStore();
+            _store = data.TestStore;
 
-
-            var carA = new Fixture().Build<Car>()
+            var carA = new Fixture().Build<CarLinqOrder>()
               .With(x => x.Make, "Mazda")
               .With(y => y.Model, "A")
               .Create();
 
-            var carB = new Fixture().Build<Car>()
+            var carB = new Fixture().Build<CarLinqOrder>()
                 .With(x => x.Make, "Mazda")
                 .With(y => y.Model, "B")
                 .Create();
 
             using (var session = _store.OpenSession())
             {
-                session.Store<Car>(carA);
-                session.Store<Car>(carB);
+                session.Store(carA);
+                session.Store(carB);
                 session.SaveChanges();
             }
         }
@@ -40,7 +37,7 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var cars = session.Query<Car>().Where(c => c.Make == "Mazda").OrderBy(o => o.Model).ToList();
+                var cars = session.Query<CarLinqOrder>().Where(c => c.Make == "Mazda").OrderBy(o => o.Model).ToList();
                 cars[0].Model.ShouldBe("A");
                 cars[1].Model.ShouldBe("B");
             }
@@ -51,7 +48,7 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var cars = session.Query<Car>().Where(c => c.Make == "Mazda").OrderByDescending(o => o.Model).ToList();
+                var cars = session.Query<CarLinqOrder>().Where(c => c.Make == "Mazda").OrderByDescending(o => o.Model).ToList();
                 cars[0].Model.ShouldBe("B");
                 cars[1].Model.ShouldBe("A");
             }
@@ -61,8 +58,19 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                session.DeleteAll<Car>();
+                session.DeleteAll<CarLinqOrder>();
             }
         }
     }
+
+    public class CarLinqOrder
+    {
+        public Guid Id { get; set; }
+        public string Make { get; set; }
+        public string Model { get; set; }
+        public string ImageUrl { get; set; }
+        public string NumberPlate { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
 }

--- a/Elephanet.Tests/LinqTests.cs
+++ b/Elephanet.Tests/LinqTests.cs
@@ -10,37 +10,37 @@ using NSubstitute;
 
 namespace Elephanet.Tests
 {
-    public class LinqTests : IDisposable
+    public class LinqTests : IClassFixture<DocumentStoreBaseFixture>, IDisposable
     {
         private IDocumentStore _store;
 
-        public LinqTests()
+        public LinqTests(DocumentStoreBaseFixture data)
         {
-            _store = new TestStore(); 
-            CreateDummyCars();
+            _store = data.TestStore; 
+            CreateDummyCar();
         }
 
-        public void CreateDummyCars()
+        public void CreateDummyCar()
         {
 
-            var dummyCars = new Fixture().Build<Car>()
+            var dummycar = new Fixture().Build<CarLinq>()
                .With(x => x.Make, "Subaru")
                .CreateMany();
 
-            var lowerCars = new Fixture().Build<Car>()
+            var lowercar = new Fixture().Build<CarLinq>()
                 .With(x => x.Make, "SAAB")
                 .CreateMany();
 
             using (var session = _store.OpenSession())
             {
-                foreach (var car in dummyCars)
+                foreach (var car in dummycar)
                 {
-                    session.Store<Car>(car);
+                    session.Store<CarLinq>(car);
                 }
 
-                foreach (var car in lowerCars)
+                foreach (var car in lowercar)
                 {
-                    session.Store<Car>(car);
+                    session.Store<CarLinq>(car);
                 }
                 session.SaveChanges();
             }
@@ -52,7 +52,7 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var results = session.Query<Car>().Where(x => x.Make == "Subaru").ToList();
+                var results = session.Query<CarLinq>().Where(x => x.Make == "Subaru").ToList();
                 results.ShouldNotBeEmpty();
             }
         }
@@ -62,11 +62,11 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var results = session.Query<Car>().Where(c => c.Make == "Subaru");
-                var cars = results.ToList();
-                cars.Count.ShouldBe(3);
-                cars.ShouldBeOfType<List<Car>>();
-                cars.ForEach(c => c.Make.ShouldBe("Subaru"));
+                var results = session.Query<CarLinq>().Where(c => c.Make == "Subaru");
+                var car = results.ToList();
+                car.Count.ShouldBe(3);
+                car.ShouldBeOfType<List<CarLinq>>();
+                car.ForEach(c => c.Make.ShouldBe("Subaru"));
               
             }
         }
@@ -77,11 +77,11 @@ namespace Elephanet.Tests
             string make = "Subaru";
             using (var session = _store.OpenSession())
             {
-                var results = session.Query<Car>().Where(c => c.Make == make);
-                var cars = results.ToList();
-                cars.Count.ShouldBe(3);
-                cars.ShouldBeOfType<List<Car>>();
-                cars.ForEach(c => c.Make.ShouldBe("Subaru"));
+                var results = session.Query<CarLinq>().Where(c => c.Make == make);
+                var car = results.ToList();
+                car.Count.ShouldBe(3);
+                car.ShouldBeOfType<List<CarLinq>>();
+                car.ForEach(c => c.Make.ShouldBe("Subaru"));
             }
 
         }
@@ -91,11 +91,11 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var results = session.Query<Car>().Where(c => c.Make == "saab".ToUpper());
-                var cars = results.ToList();
-                cars.Count.ShouldBe(3);
-                cars.ShouldBeOfType<List<Car>>();
-                cars.ForEach(c => c.Make.ShouldBe("SAAB"));
+                var results = session.Query<CarLinq>().Where(c => c.Make == "saab".ToUpper());
+                var car = results.ToList();
+                car.Count.ShouldBe(3);
+                car.ShouldBeOfType<List<CarLinq>>();
+                car.ForEach(c => c.Make.ShouldBe("SAAB"));
             }
 
         }
@@ -105,10 +105,10 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var results = session.Query<Car>().Where(c => c.Make == "SAAB").Take(2);
-                var cars = results.ToList();
-                cars.Count.ShouldBe(2);
-                cars.ShouldBeOfType<List<Car>>();
+                var results = session.Query<CarLinq>().Where(c => c.Make == "SAAB").Take(2);
+                var car = results.ToList();
+                car.Count.ShouldBe(2);
+                car.ShouldBeOfType<List<CarLinq>>();
             }
         }
 
@@ -117,10 +117,10 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                var results = session.Query<Car>().Where(c => c.Make == "SAAB").Skip(2);
-                var cars = results.ToList();
-                cars.Count.ShouldBe(1);
-                cars.ShouldBeOfType<List<Car>>();
+                var results = session.Query<CarLinq>().Where(c => c.Make == "SAAB").Skip(2);
+                var car = results.ToList();
+                car.Count.ShouldBe(1);
+                car.ShouldBeOfType<List<CarLinq>>();
             }
 
         }
@@ -129,8 +129,18 @@ namespace Elephanet.Tests
         {
             using (var session = _store.OpenSession())
             {
-                session.DeleteAll<Car>();
+                session.DeleteAll<CarLinq>();
             }
         }
+    }
+
+    public class CarLinq
+    {
+        public Guid Id { get; set; }
+        public string Make { get; set; }
+        public string Model { get; set; }
+        public string ImageUrl { get; set; }
+        public string NumberPlate { get; set; }
+        public DateTime CreatedAt { get; set; }
     }
 }

--- a/Elephanet.Tests/QueryTests.cs
+++ b/Elephanet.Tests/QueryTests.cs
@@ -4,8 +4,15 @@ using Shouldly;
 
 namespace Elephanet.Tests
 {
-    public class QueryTests
+    public class QueryTests : IClassFixture<DocumentStoreBaseFixture>, IDisposable
     {
+        private TestStore _store;
+
+        public QueryTests(DocumentStoreBaseFixture data)
+        {
+            _store = data.TestStore;
+        }
+
         [Fact]
         public void SingleQuotes_ShouldBe_EscapedWhenSaving()
         {
@@ -14,22 +21,27 @@ namespace Elephanet.Tests
             car.Make = "Kia";
             car.Model = "Cee'd";
 
-            var store = new TestStore();
+          
             //save the car
-            using (var session = store.OpenSession())
+            using (var session = _store.OpenSession())
             {
                 session.Store(car);
                 session.SaveChanges();
             }
 
             //retrieve and check the make and model are correct
-            using (var session = store.OpenSession())
+            using (var session = _store.OpenSession())
             {
                 var savedCar = session.GetById<Car>(car.Id);
                 savedCar.Model.ShouldBe("Cee'd");
                 savedCar.Make.ShouldBe("Kia");
 
             }
+        }
+
+        public void Dispose()
+        {
+            
         }
     }
 }

--- a/Elephanet.Tests/packages.config
+++ b/Elephanet.Tests/packages.config
@@ -3,6 +3,10 @@
   <package id="AutoFixture" version="3.20.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
   <package id="Shouldly" version="2.1.1" targetFramework="net45" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.0.0-rc3-build1046" targetFramework="net45" />
 </packages>

--- a/Elephanet/packages.config
+++ b/Elephanet/packages.config
@@ -3,4 +3,5 @@
   <package id="Jil" version="2.8.1" targetFramework="net45" />
   <package id="Npgsql" version="2.2.4.3" targetFramework="net45" />
   <package id="Sigil" version="4.4.0" targetFramework="net45" />
+  <package id="xunit.runner.console" version="2.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
…of the test fixtures and injected the global TestStore into the tests.

This should expose threading issues as Xunit 2.0 parallelizes the execution of Test Fixtures by default
Also had to use dto/entities per fixture in order to avoid cross fixture collision/contamination (because of the parallelization)